### PR TITLE
[CORRECT] 수정사항 18번 기록 선택 시 이미지 확대 문제 해결

### DIFF
--- a/MC2-LESSERAFIM/RecordCollection/RecordCollectionView.swift
+++ b/MC2-LESSERAFIM/RecordCollection/RecordCollectionView.swift
@@ -289,7 +289,7 @@ struct PostDetailView: View {
     var body: some View {
         (Image.fromData(post.imageData ?? Data())  ?? Image(systemName: "x.circle"))
             .resizable()
-            .scaledToFill()
+            .aspectRatio(contentMode: .fit)
             .ignoresSafeArea()
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {


### PR DESCRIPTION
- 이미지(사진/그림) 원래 비율 유지한 채 보이게 수정

**사진 첨부 시 보이는 크롭된 이미지와 달리 기록에서 볼 경우 원본 비율이 유지된 이미지로 보이는 문제 발생 -> 수정사항 22번 추가