### PR TITLE
[CORRECT] 기록모음 이미지 표출 방식 변경 

### DIFF
--- a/MC2-LESSERAFIM/RecordCollection/RecordCollectionView.swift
+++ b/MC2-LESSERAFIM/RecordCollection/RecordCollectionView.swift
@@ -216,8 +216,8 @@ struct GalleryView: View {
                     } label: {
                         (Image.fromData(post.imageData ?? Data())  ?? Image(systemName: "x.circle"))
                             .resizable()
-                            .scaledToFit()
-                            .frame(minHeight: 172)
+                            .aspectRatio(contentMode: .fill)    // 프레임 내에 이미지 가득 채우기
+                            .frame(width: 129, height: 172)
                             .background(
                                 LinearGradient(gradient: Gradient(colors: [Color(.systemGray5), Color(.systemGray2)]),
                                                startPoint: .top, endPoint: .bottom)


### PR DESCRIPTION
- 기존
  - 이미지 비율 유지한 채 여백 회색 처리
  - 이미지 비율이 세로가 길 경우 해당 행의 높이가 기준 초과
  - <img width="391" alt="image" src="https://github.com/MC2-LESSERAFIM/MC2-LESSERAFIM/assets/127754551/fffff499-f499-44d3-a966-67f188144ef2">

- 변경
  - 이미지 비율 유지한 채 프레임 초과 부분 크롭 처리
  - <img width="391" alt="image" src="https://github.com/MC2-LESSERAFIM/MC2-LESSERAFIM/assets/127754551/83b670ba-9921-4695-8cb7-7ad0783d3d2d">
 
