### PR TITLE
[CORRECT] 사진 첨부 화면에서도 사진 원본 비율로 첨부

### DIFF
--- a/MC2-LESSERAFIM/Challenge/Record/Picture/WritingView.swift
+++ b/MC2-LESSERAFIM/Challenge/Record/Picture/WritingView.swift
@@ -93,7 +93,7 @@ struct WritingView: View {
                             else{
                                 profileImage!
                                     .resizable()
-                                    .scaledToFill()
+                                    .aspectRatio(contentMode: .fit)
                                     .frame(width: geo.size.width - 40, height: geo.size.height - 239, alignment: .center)
                                     .clipped()
                             }


### PR DESCRIPTION
- 모든 이미지(기록뷰, 기록모음 디테일뷰)는 크롭 없이 원본 비율로 취급합니다.