### PR TITLE
[MERGE] 챌린지 수행 완료 튜토리얼 뷰 생성 및 subText color extension 수정 머지 9

### DIFF
--- a/MC2-LESSERAFIM.xcodeproj/project.pbxproj
+++ b/MC2-LESSERAFIM.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		D25C13FC2A12B10E007FC37C /* ChallengeCheckScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D25C13FB2A12B10E007FC37C /* ChallengeCheckScreen.swift */; };
 		D25C13FE2A12B415007FC37C /* CustomButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D25C13FD2A12B415007FC37C /* CustomButton.swift */; };
 		D25C14002A12C36B007FC37C /* NotYetChallengeScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D25C13FF2A12C36B007FC37C /* NotYetChallengeScreen.swift */; };
+		D25C14022A13272B007FC37C /* RecordCompleteScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D25C14012A13272B007FC37C /* RecordCompleteScreen.swift */; };
 		D294526C2A0C7F7C0053F42F /* SmallOnBoarding.swift in Sources */ = {isa = PBXBuildFile; fileRef = D294526B2A0C7F7C0053F42F /* SmallOnBoarding.swift */; };
 		D2A4776E2A0890EE0055B95E /* DataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A4776D2A0890EE0055B95E /* DataModel.swift */; };
 		D2D82FDE2A0CE00D004D91B7 /* SelectedUserCharacterScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D82FDD2A0CE00D004D91B7 /* SelectedUserCharacterScreen.swift */; };
@@ -101,6 +102,7 @@
 		D25C13FB2A12B10E007FC37C /* ChallengeCheckScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeCheckScreen.swift; sourceTree = "<group>"; };
 		D25C13FD2A12B415007FC37C /* CustomButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomButton.swift; sourceTree = "<group>"; };
 		D25C13FF2A12C36B007FC37C /* NotYetChallengeScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotYetChallengeScreen.swift; sourceTree = "<group>"; };
+		D25C14012A13272B007FC37C /* RecordCompleteScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordCompleteScreen.swift; sourceTree = "<group>"; };
 		D294526B2A0C7F7C0053F42F /* SmallOnBoarding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmallOnBoarding.swift; sourceTree = "<group>"; };
 		D2A4776D2A0890EE0055B95E /* DataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataModel.swift; sourceTree = "<group>"; };
 		D2D82FDD2A0CE00D004D91B7 /* SelectedUserCharacterScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedUserCharacterScreen.swift; sourceTree = "<group>"; };
@@ -266,6 +268,7 @@
 				BF7520552A09DDE700BF81DC /* Writing */,
 				BF7520572A09DE0700BF81DC /* Picture */,
 				BF7520562A09DDF700BF81DC /* Painting */,
+				D25C14012A13272B007FC37C /* RecordCompleteScreen.swift */,
 			);
 			path = Record;
 			sourceTree = "<group>";
@@ -484,6 +487,7 @@
 				8E15E4C92A087BC7003C7D3F /* RecordSelectionView.swift in Sources */,
 				A1A17E6F2A0C7F88009D4136 /* BiometricLock.swift in Sources */,
 				D25C13FC2A12B10E007FC37C /* ChallengeCheckScreen.swift in Sources */,
+				D25C14022A13272B007FC37C /* RecordCompleteScreen.swift in Sources */,
 				BFCC38462A0EC59900CC9CA7 /* Model.xcdatamodeld in Sources */,
 				A15ED6DC2A04D8390039EFC7 /* CanvusColorPickerView.swift in Sources */,
 				A1EF9E612A02562000A56E4C /* ContentView.swift in Sources */,

--- a/MC2-LESSERAFIM/Challenge/ChallengeCheckScreen.swift
+++ b/MC2-LESSERAFIM/Challenge/ChallengeCheckScreen.swift
@@ -32,7 +32,7 @@ struct ChallengeCheckScreen: View {
                     .font(.system(size: 17))
                     .lineSpacing(4)
                     .multilineTextAlignment(.leading)
-                    .foregroundColor(.gray)
+                    .foregroundColor(.subText)
                     .padding(.top, 12)
                 
                 HStack(spacing: 18) {

--- a/MC2-LESSERAFIM/Challenge/ChallengeScreen.swift
+++ b/MC2-LESSERAFIM/Challenge/ChallengeScreen.swift
@@ -85,7 +85,7 @@ struct ChallengeScreen: View {
                                 
                                 Text("다시 뽑기 \(numberOfTimeLeft)회")
                                     .font(.system(size: 14, weight: .regular))
-                                    .foregroundColor(.gray)
+                                    .foregroundColor(.subText)
                             }
                             .padding(.horizontal, 24)
                             

--- a/MC2-LESSERAFIM/Challenge/NotYetChallengeScreen.swift
+++ b/MC2-LESSERAFIM/Challenge/NotYetChallengeScreen.swift
@@ -22,7 +22,7 @@ struct NotYetChallengeScreen: View {
                     .font(.system(size: 17))
                     .lineSpacing(4)
                     .multilineTextAlignment(.leading)
-                    .foregroundColor(.gray)
+                    .foregroundColor(.subText)
                     .padding(.top, 12)
                 
                 Spacer()

--- a/MC2-LESSERAFIM/Challenge/Record/RecordCompleteScreen.swift
+++ b/MC2-LESSERAFIM/Challenge/Record/RecordCompleteScreen.swift
@@ -1,0 +1,58 @@
+//
+//  RecordCompleteScreen.swift
+//  MC2-LESSERAFIM
+//
+//  Created by 손서연 on 2023/05/16.
+//
+
+import SwiftUI
+
+struct RecordCompleteScreen: View {
+    @AppStorage("userName") var userName: String = ""
+    
+    @State private var navigationIsActive: Bool = false
+    
+    var body: some View {
+        ZStack {
+            BackgroundView()
+            VStack {
+                
+                VStack(alignment: .leading, spacing: 0){
+                    // 화면 타이틀(PageTitle)
+                    PageTitle(titlePage: "챌린지 기록을 완료했어요!")
+                    
+                    VStack(alignment: .leading, spacing: 19) {
+                        Text("챌린지를 통해 성장한 덕분에\n\(userName)만의 새로운 색깔을 발견했어요.")
+                        
+                        Text("각 챌린지를 통해 내 다양한 모습을 찾아가면서\n다채로워지는 \(userName)만의 색깔을 즐겨보세요!😉")
+                    }
+                    .font(.system(size: 17))
+                    .lineSpacing(4)
+                    .multilineTextAlignment(.leading)
+                    .foregroundColor(.subText)
+                    .padding(.top, 12)
+                }
+                Spacer()
+                
+                NavigationLink {
+                    ChallengeScreen()
+                } label: {
+                    Text("좋아요!")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(NextButtonStyle(isAbled: true))
+            }
+            .padding(.horizontal, 24)
+            .padding(.top, 100)
+            .padding(.bottom, 100)
+            .ignoresSafeArea()
+        }
+        .navigationTitle("")
+    }
+}
+
+struct RecordCompleteScreen_Previews: PreviewProvider {
+    static var previews: some View {
+        RecordCompleteScreen()
+    }
+}

--- a/MC2-LESSERAFIM/Challenge/RecordSelectionView.swift
+++ b/MC2-LESSERAFIM/Challenge/RecordSelectionView.swift
@@ -33,7 +33,7 @@ struct RecordSelectionView: View {
                         .font(.system(size: 17))
                         .lineSpacing(4)
                         .multilineTextAlignment(.leading)
-                        .foregroundColor(.gray)
+                        .foregroundColor(.subText)
                         .padding(.top, 12)
                 }
                 

--- a/MC2-LESSERAFIM/Components/CustomButton.swift
+++ b/MC2-LESSERAFIM/Components/CustomButton.swift
@@ -40,7 +40,7 @@ struct SelectableButton: View {
             .cornerRadius(12)
             .overlay {
                 RoundedRectangle(cornerRadius: 10)
-                    .stroke(isSelected ? Color.mainPink : Color.mainPinkOpacity, lineWidth: 2)
+                    .stroke(isSelected ? Color.mainPink : Color.mainPinkOpacity, lineWidth: 1)
             }
         }
     }

--- a/MC2-LESSERAFIM/Extensions/ColorExtension.swift
+++ b/MC2-LESSERAFIM/Extensions/ColorExtension.swift
@@ -26,4 +26,5 @@ extension Color {
         .opacity(0.7)
     static let opacityWhiteChallenge = Color(hex: "FFFFFF") //버튼
         .opacity(0.3)
+    static let subText = Color(hex: "757575")
 }

--- a/MC2-LESSERAFIM/OnBoarding/CheckInScreen.swift
+++ b/MC2-LESSERAFIM/OnBoarding/CheckInScreen.swift
@@ -32,7 +32,7 @@ struct CheckInScreen: View {
                     .font(.system(size: 17))
                     .lineSpacing(4)
                     .multilineTextAlignment(.leading)
-                    .foregroundColor(.gray)
+                    .foregroundColor(.subText)
                     .padding(.top, 12)
                 
                 UserNameTextField(username: $userName, placeholder: "호칭을 적어주세요")

--- a/MC2-LESSERAFIM/OnBoarding/UserCharacter/SelectedUserCharacterScreen.swift
+++ b/MC2-LESSERAFIM/OnBoarding/UserCharacter/SelectedUserCharacterScreen.swift
@@ -26,7 +26,7 @@ struct SelectedUserCharacterScreen: View {
                 Text("스와이프하여 마음에 드는 캐릭터의 배를 콕 찌른 뒤 다음 버튼을 눌러주세요.")
                     .font(.system(size: 17))
                     .multilineTextAlignment(.leading)
-                    .foregroundColor(.gray)
+                    .foregroundColor(.subText)
                     .padding(.top, 12)
                 
                 Spacer()


### PR DESCRIPTION
## 수정한 뷰
### subText 추가
- ColorExtension
### subText 추가에 따른 코드 변경
- ChallengeCheckScreen
- ChallengeScreen
- NotYetChallengeScreen
- RecordSelectionView
- CheckInScreen
- SelectedUserCharacterScreen

## 추가한 뷰
- RecordCompleteScreen (사용자가 최초로 챌린지를 기록하여 완료할 경우 나타나는 뷰. 최초 1회 이후에는 뜨지 않습니다.)